### PR TITLE
fix: call UIImageView initializer on main thread

### DIFF
--- a/AdButler/AdButler/Placement+ImageView.swift
+++ b/AdButler/AdButler/Placement+ImageView.swift
@@ -28,14 +28,12 @@ public extension Placement {
             guard let httpResponse = response as? HTTPURLResponse, let data = data, httpResponse.statusCode == 200 else {
                 return
             }
-            
-            let image = UIImage(data: data)
-            let imageView = ABImageView(image: image)
-            imageView.placement = self
-            
             DispatchQueue.main.async {
-                complete(imageView)
+                let image = UIImage(data: data)
+                let imageView = ABImageView(image: image)
+                imageView.placement = self
                 imageView.setupGestures()
+                complete(imageView)
             }
         }
         task.resume()


### PR DESCRIPTION
`ABImageView` is instantiated outside the `DispatchQueue.main.async` callback in a background thread. This results in the following warning: `runtime: UI API called from background thread: UIImageView.init(image:) must be used from main thread only`.

I've moved the `image` and `imageView` instances into the async callback/block. I'm also calling `imageView.setupGestures()` before `completion()` instead of after (is that okay or is there a reason for calling it after `completion()`?)